### PR TITLE
Restrict cursor gradient to wide screens

### DIFF
--- a/app/_components/backdrop.tsx
+++ b/app/_components/backdrop.tsx
@@ -4,32 +4,59 @@ import React from "react";
 
 type Position = [number, number];
 
+const WIDE_SCREEN_QUERY = "(min-width: 1024px)";
+
 export function Backdrop() {
+	const [isWideScreen, setIsWideScreen] = React.useState(false);
 	const [position, setPosition] = React.useState<Position>([0, 0]);
 	const lastMousePos = React.useRef<Position>([0, 0]);
 
-	const updatePosition = () => {
-		// Use last known mouse position relative to viewport, no scroll offset needed for fixed element
-		setPosition(lastMousePos.current);
-	};
+	React.useEffect(() => {
+		const wideScreenMedia = window.matchMedia(WIDE_SCREEN_QUERY);
 
-	const onMouseMove = (event: MouseEvent) => {
-		lastMousePos.current = [event.clientX, event.clientY];
-		updatePosition();
-	};
+		const updateWideScreen = () => {
+			setIsWideScreen(wideScreenMedia.matches);
+		};
 
-	const onScroll = () => {
-		updatePosition();
-	};
+		updateWideScreen();
+		wideScreenMedia.addEventListener("change", updateWideScreen);
+
+		return () => {
+			wideScreenMedia.removeEventListener("change", updateWideScreen);
+		};
+	}, []);
 
 	React.useEffect(() => {
+		if (!isWideScreen) {
+			return;
+		}
+
+		const updatePosition = () => {
+			// Use last known mouse position relative to viewport, no scroll offset needed for fixed element
+			setPosition(lastMousePos.current);
+		};
+
+		const onMouseMove = (event: MouseEvent) => {
+			lastMousePos.current = [event.clientX, event.clientY];
+			updatePosition();
+		};
+
+		const onScroll = () => {
+			updatePosition();
+		};
+
 		document.addEventListener("mousemove", onMouseMove);
 		window.addEventListener("scroll", onScroll);
+
 		return () => {
 			document.removeEventListener("mousemove", onMouseMove);
 			window.removeEventListener("scroll", onScroll);
 		};
-	}, []);
+	}, [isWideScreen]);
+
+	if (!isWideScreen) {
+		return null;
+	}
 
 	return (
 		<div


### PR DESCRIPTION
### Motivation
- The cursor-following radial gradient should only appear on desktop/wide viewports and be disabled on narrow/vertical mobile layouts so the static background is shown on mobile.

### Description
- Add `WIDE_SCREEN_QUERY = "(min-width: 1024px)"` and track viewport state with `window.matchMedia`.
- Introduce an `isWideScreen` state and only attach `mousemove` and `scroll` listeners while the media query matches.
- Return `null` (no backdrop overlay) when not wide-screen so the static body background remains visible.
- Keep the existing radial-gradient rendering and transition behavior for wide screens.

### Testing
- Ran `pnpm lint` (via `biome check`) which succeeded with no fixes applied.
- Ran `pnpm build` which failed due to Next.js being unable to fetch the Google Font `Space Grotesk` from `fonts.googleapis.com` in this environment, unrelated to the backdrop change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35ff956878832591b15498d56f5cde)